### PR TITLE
Enable dependency update robot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "21:00"
+  open-pull-requests-limit: 30


### PR DESCRIPTION
Using dependency update robots to replace part of the work may make you work more efficiently.
Please refer to the detailed usage documents.

[Enabling and disabling version updates](https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates)