### PR TITLE
Execution bundle of goal org.apache.maven.plugins:maven-assembly-plug…

### DIFF
--- a/alibaba-broker-server/pom.xml
+++ b/alibaba-broker-server/pom.xml
@@ -225,6 +225,7 @@
                 <configuration>
                     <finalName>alibaba-rsocket-broker-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <descriptors>
                         <descriptor>${basedir}/src/main/build/assembly.xml</descriptor>
                     </descriptors>


### PR DESCRIPTION
…in:3.2.0:single failed: group id '1603212982' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]