### PR TITLE
feat(alibaba-rsocket-core): new design for rsocket-broker's error code.

### DIFF
--- a/alibaba-rsocket-core/pom.xml
+++ b/alibaba-rsocket-core/pom.xml
@@ -29,6 +29,11 @@
             <version>${cloudevents.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.kevinten</groupId>
+            <artifactId>vrml-error</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
             <version>1.1.1</version>

--- a/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/observability/RsocketErrorCodeContext.java
+++ b/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/observability/RsocketErrorCodeContext.java
@@ -1,0 +1,52 @@
+package com.alibaba.rsocket.observability;
+
+import com.kevinten.vrml.error.code.ErrorCodeContext;
+
+/**
+ * The Rsocket error code context.
+ */
+public interface RsocketErrorCodeContext extends ErrorCodeContext {
+
+    /**
+     * The RsocketErrorCode GENERATOR.
+     */
+    RsocketErrorCodeGenerator GENERATOR = new RsocketErrorCodeGenerator();
+    /**
+     * The RsocketErrorCode MANAGER.
+     */
+    RsocketErrorCodeManager MANAGER = new RsocketErrorCodeManager();
+
+    /**
+     * The Rsocket error code generator.
+     */
+    class RsocketErrorCodeGenerator implements ErrorCodeGenerator {
+
+        /**
+         * Rsocket system code.
+         *
+         * @apiNote code like {@code RST-xxxxx}.
+         */
+        private static final String DEFAULT_APPLICATION_CODE = "RST-";
+
+        @Override
+        public String createErrorCode(String prefix, String code) {
+            return applicationErrorCode() + prefix + code;
+        }
+
+        @Override
+        public String applicationErrorCode() {
+            return DEFAULT_APPLICATION_CODE;
+        }
+    }
+
+    /**
+     * The Rsocket error code manager.
+     */
+    class RsocketErrorCodeManager implements ErrorCodeManager<RsocketErrorCodeContext> {
+
+        @Override
+        public void showErrorCodeItem(RsocketErrorCodeContext errorCodeContext) {
+            System.out.printf("%70s  %5s  %s", errorCodeContext.name(), errorCodeContext.getCode(), errorCodeContext.getMessage());
+        }
+    }
+}

--- a/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/observability/RsocketErrorCodes.java
+++ b/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/observability/RsocketErrorCodes.java
@@ -1,0 +1,85 @@
+package com.alibaba.rsocket.observability;
+
+/**
+ * Rsocket broker error info context:
+ * [RST-200000] SUCCESS
+ * [RST-1xxxxx] {@code parameter} error. Define parameter check exception
+ * [RST-2xxxxx] {@code business} error. Define business logic exception
+ * [RST-3xxxxx] {@code repository service}. Define repository operation exception
+ * [RST-4xxxxx] {@code dependent service}. Define dependency service exception
+ * [RST-5xxxxx] {@code system} error. Define application system exception
+ */
+public enum RsocketErrorCodes implements RsocketErrorCodeContext {
+
+    /**
+     * The successful error code.
+     */
+    SUCCESS("200000", "Success"),
+
+    /*-------------------------------------------Parameter error as below---------------------------------------**/
+    /**
+     * Invalid basic parameter error, the code starts with 0.
+     */
+    PARAMETER_ERROR(
+            GENERATOR.createParameterErrorCode("00000"), "Invalid parameter error!"),
+
+    /*-------------------------------------------Business error as below---------------------------------------**/
+    /**
+     * Basic business error, the code starts with 0.
+     */
+    BUSINESS_ERROR(
+            GENERATOR.createBusinessProcessErrorCode("00001"), "Business error!"),
+
+    /*-------------------------------------------Repository error as below---------------------------------------**/
+    /**
+     * Basic repository error, the code starts with 0.
+     */
+    REPOSITORY_ERROR(
+            GENERATOR.createRepositoryErrorCode("00000"), "Repository error!"),
+
+    /*-------------------------------------------Dependent service error as below---------------------------------------**/
+    /**
+     * Basic dependent service error, the code starts with 0.
+     */
+    DEPENDENT_SERVICE_ERROR(
+            GENERATOR.createDependentServiceErrorCode("00000"), "Failed to call the dependent service!"),
+
+    /*-------------------------------------------System error as below---------------------------------------**/
+    /**
+     * Basic system error, the code starts with 0.
+     */
+    SYSTEM_ERROR(
+            GENERATOR.createSystemErrorCode("00000"), "System error!"),
+    ;
+
+    // -- Encapsulation
+
+    private final String code;
+    private final String message;
+
+    RsocketErrorCodes(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    static {
+        ErrorCodeManager.assertErrorCodesNoDuplicate(RsocketErrorCodes.values());
+    }
+
+    /**
+     * Show error codes.
+     */
+    public static void showErrorCodes() {
+        MANAGER.showErrorCodes(RsocketErrorCodes.values());
+    }
+}


### PR DESCRIPTION
For the specification of Error Code Design, please refer to
https://github.com/kevinten10/vrml/blob/master/vrml-error/WIKI.md

In the end, we should have several categories:

RST-1xxxxx [Parameter error]
RST-2xxxxx [Logic Error]
RST-3xxxxx [Storage error]
RST-4xxxxx [dependency error]
RST-5xxxxx [System Error]

And through centralized management and notes, people can read and understand clearly.

At the same time, by using centralized management, we can avoid the magic numbers scattered everywhere. The concept is the same as issue #103 .
Even generate documents automatically.